### PR TITLE
feat: Add Spendy project to portfolio

### DIFF
--- a/src/data/resume-data.tsx
+++ b/src/data/resume-data.tsx
@@ -97,7 +97,7 @@ export const RESUME_DATA = {
       title: "Spendy",
       techStack: ["TypeScript", "Next.js", "Prisma", "Tailwind CSS"],
       description:
-        "Spendy is a simple, fast, and secure way to track your spending. Features include categorizing spending, creating custom categories, searching categories, viewing spending history, and exporting to CSV. Future features include budget creation.",
+        "Spendy is a simple, fast, and secure way to track your spending. Features include categorizing spending, viewing spending history, and exporting to CSV.",
       logo: Minimal, // Using MinimalLogo as a placeholder
       link: {
         label: "spendy-ashy.vercel.app",

--- a/src/data/resume-data.tsx
+++ b/src/data/resume-data.tsx
@@ -98,7 +98,7 @@ export const RESUME_DATA = {
       techStack: ["TypeScript", "Next.js", "Prisma", "Tailwind CSS"],
       description:
         "Spendy is a simple, fast, and secure way to track your spending. Features include categorizing spending, creating custom categories, searching categories, viewing spending history, and exporting to CSV. Future features include budget creation.",
-      logo: MinimalLogo, // Using MinimalLogo as a placeholder
+      logo: Minimal, // Using MinimalLogo as a placeholder
       link: {
         label: "spendy-ashy.vercel.app",
         href: "https://spendy-ashy.vercel.app/",

--- a/src/data/resume-data.tsx
+++ b/src/data/resume-data.tsx
@@ -94,6 +94,17 @@ export const RESUME_DATA = {
   ],
   projects: [
     {
+      title: "Spendy",
+      techStack: ["TypeScript", "Next.js", "Prisma", "Tailwind CSS"],
+      description:
+        "Spendy is a simple, fast, and secure way to track your spending. Features include categorizing spending, creating custom categories, searching categories, viewing spending history, and exporting to CSV. Future features include budget creation.",
+      logo: MinimalLogo, // Using MinimalLogo as a placeholder
+      link: {
+        label: "spendy-ashy.vercel.app",
+        href: "https://spendy-ashy.vercel.app/",
+      },
+    },
+    {
       title: "Acme Dashboard",
       techStack: ["Side Project", "TypeScript", "Next.js"],
       description: "A platform to see invoices and customers",


### PR DESCRIPTION
Updates the projects section in resume-data.tsx to include the 'Spendy' project.

- Adds 'Spendy' with its tech stack (TypeScript, Next.js, Prisma, Tailwind CSS) and description.
- Places 'Spendy' at the top of the projects list.
- Uses a placeholder logo (MinimalLogo) for now.